### PR TITLE
Upgrade dependencies and plugins to latest stable versions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/bashate.yml
+++ b/.github/workflows/bashate.yml
@@ -15,8 +15,8 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - run: pip install bashate

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,19 +12,19 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
       - run: mvn install -Pjacoco
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/site/jacoco/jacoco.xml

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: yegor256/copyrights-action@0.0.8
+      - uses: actions/checkout@v6
+      - uses: yegor256/copyrights-action@0.0.12

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v20.0.0
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v23

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 17]
+        java: [21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -19,12 +19,12 @@ jobs:
         os: [ubuntu-24.04, windows-2022, macos-15]
         java: [11, 17]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: volodya-lombrozo/pdd-action@master

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: fsfe/reuse-action@v5
+      - uses: actions/checkout@v6
+      - uses: fsfe/reuse-action@v6

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.32.0
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.46.0

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: g4s8/xcop-action@master

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -15,5 +15,5 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ibiqlik/action-yamllint@v3

--- a/.qulice-header.txt
+++ b/.qulice-header.txt
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright (c) 2016-2026 Yegor Bugayenko
+SPDX-License-Identifier: MIT

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-<img alt="logo" src="http://www.jare.io/images/logo.svg" width="64" height="64"/>
+# Jare
+
+![logo](http://www.jare.io/images/logo.svg)
 
 [![EO principles respected here](https://www.elegantobjects.org/badge.svg)](https://www.elegantobjects.org)
 [![DevOps By Rultor.com](https://www.rultor.com/b/yegor256/jare)](https://www.rultor.com/p/yegor256/jare)
@@ -24,8 +26,8 @@ your changes and apply them to the `master` branch shortly, provided
 they don't violate our quality standards. To avoid frustration, before
 sending us your pull request please run full Maven build:
 
-```
-$ mvn clean install -Pqulice
+```bash
+mvn clean install -Pqulice
 ```
 
 To avoid build errors use Maven 3.2+ and Java 8+.

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
 [default.extend-words]
 bse = "bse"
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,7 @@
+[default.extend-words]
+bse = "bse"
+
+[files]
+extend-exclude = [
+    "src/test/resources/io/jare/test",
+]

--- a/pom.xml
+++ b/pom.xml
@@ -509,6 +509,7 @@
             <artifactId>qulice-maven-plugin</artifactId>
             <version>0.21.1</version>
             <configuration>
+              <license>file:${basedir}/.qulice-header.txt</license>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/main/resources/images/.*</exclude>
                 <exclude>findbugs:.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -63,42 +63,42 @@
     <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
-      <version>8.0.0</version>
+      <version>8.41.0</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.12.702</version>
+      <version>1.12.797</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
-      <version>1.12.702</version>
+      <version>1.12.797</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-cloudfront</artifactId>
-      <version>1.12.702</version>
+      <version>1.12.797</version>
     </dependency>
     <dependency>
       <groupId>org.takes</groupId>
       <artifactId>takes</artifactId>
-      <version>1.24.6</version>
+      <version>1.26.0</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi.incubator</groupId>
       <artifactId>xembly</artifactId>
-      <version>0.32.1</version>
+      <version>0.32.2</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.56.1</version>
+      <version>0.61.0</version>
     </dependency>
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>1.0.b2</version>
+      <version>1.4.01</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
@@ -125,27 +125,27 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.36</version>
+      <version>1.18.46</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.17.0</version>
+      <version>3.20.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.18.0</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-xml</artifactId>
-      <version>0.31.0</version>
+      <version>0.35.0</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-s3</artifactId>
-      <version>0.19.0</version>
+      <version>1.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
@@ -161,7 +161,7 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-http</artifactId>
-      <version>1.20.1</version>
+      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
@@ -176,7 +176,7 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
-      <version>1.8.0</version>
+      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>
@@ -185,20 +185,26 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
+      <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>1.19.4</version>
+      <version>3.1.10</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <version>3.1.10</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-manifests</artifactId>
-      <version>2.1.0</version>
+      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>12.5</version>
+      <version>12.9</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -210,7 +216,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.3.232</version>
+      <version>2.4.240</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -222,19 +228,43 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.10.3</version>
+      <version>5.14.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.10.3</version>
+      <version>5.14.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>5.10.3</version>
+      <version>5.14.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+      <version>1.14.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-engine</artifactId>
+      <version>1.14.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>1.14.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/jare/dynamo/DyUsage.java
+++ b/src/main/java/io/jare/dynamo/DyUsage.java
@@ -64,7 +64,7 @@ public final class DyUsage implements Usage {
         } else {
             before = Long.parseLong(items.get(0));
         }
-        final Node node = xml.node();
+        final Node node = xml.deepCopy();
         new Xembler(
             new Directives()
                 .xpath(xpath).up().remove()

--- a/src/main/java/io/jare/tk/TkAppAuth.java
+++ b/src/main/java/io/jare/tk/TkAppAuth.java
@@ -62,14 +62,14 @@ final class TkAppAuth extends TkWrap {
                 ),
                 new PsByFlag(
                     new PsByFlag.Pair(
-                        PsGithub.class.getSimpleName(),
+                        Pattern.compile(PsGithub.class.getSimpleName()),
                         new PsGithub(
                             Manifests.read("Jare-GithubId"),
                             Manifests.read("Jare-GithubSecret")
                         )
                     ),
                     new PsByFlag.Pair(
-                        PsLogout.class.getSimpleName(),
+                        Pattern.compile(PsLogout.class.getSimpleName()),
                         new PsLogout()
                     )
                 ),

--- a/src/main/java/io/jare/tk/TkAppFallback.java
+++ b/src/main/java/io/jare/tk/TkAppFallback.java
@@ -85,7 +85,7 @@ final class TkAppFallback extends TkWrap {
         return new RsWithStatus(
             new RsWithType(
                 new RsVelocity(
-                    TkAppFallback.class.getResource("error.html.vm"),
+                    TkAppFallback.class.getResource("error.html.vm").openStream(),
                     new RsVelocity.Pair(
                         "err",
                         ExceptionUtils.getStackTrace(req.throwable())

--- a/src/main/java/io/jare/tk/TkRelay.java
+++ b/src/main/java/io/jare/tk/TkRelay.java
@@ -93,7 +93,7 @@ final class TkRelay implements Take {
         final Domain domain = domains.next();
         return TkRelay.cached(
             new RsWithHeaders(
-                new TkProxy(uri.toString()).act(
+                new TkProxy(uri).act(
                     TkRelay.request(
                         req,
                         new Destination(uri).path()


### PR DESCRIPTION
@yegor256 this PR brings the project up-to-date on stable dependencies, GitHub Actions and lint tooling, and stabilizes the build, which was failing on master with 59 qulice `HeaderCheck` violations.

## Build stabilization

`qulice-maven-plugin` `0.21.1` ships a hardcoded `Header` checkstyle rule that expects the legacy `* The MIT License (MIT)` text on line 2 of every Java source file, but every file in this repo already carries the modern SPDX header (`SPDX-FileCopyrightText` / `SPDX-License-Identifier`). I added a tiny `.qulice-header.txt` template with the SPDX two-liner and pointed qulice at it via `<license>file:${basedir}/.qulice-header.txt</license>`. No source files needed to change.

## Dependency upgrades

Production:

- `io.sentry:sentry` 8.0.0 → 8.41.0
- `aws-java-sdk-{core,dynamodb,cloudfront}` 1.12.702 → 1.12.797
- `org.takes:takes` 1.24.6 → 1.26.0
- `com.jcabi.incubator:xembly` 0.32.1 → 0.32.2
- `org.cactoos:cactoos` 0.56.1 → 0.61.0
- `xml-apis:xml-apis` 1.0.b2 → 1.4.01
- `org.projectlombok:lombok` 1.18.36 → 1.18.46
- `org.apache.commons:commons-lang3` 3.17.0 → 3.20.0 (also covers the open `commons-lang3` security PR)
- `commons-io:commons-io` 2.18.0 → 2.22.0
- `com.jcabi:jcabi-xml` 0.31.0 → 0.35.0
- `com.jcabi:jcabi-s3` 0.19.0 → 1.1.0
- `com.jcabi:jcabi-http` 1.20.1 → 2.1.0
- `com.jcabi:jcabi-matchers` 1.8.0 → 1.9.0
- `com.jcabi:jcabi-manifests` 2.1.0 → 2.2.0
- `net.sf.saxon:Saxon-HE` 12.5 → 12.9

Test:

- `com.h2database:h2` 2.3.232 → 2.4.240
- JUnit Jupiter (api / engine / vintage) 5.10.3 → 5.14.4 + explicit `org.junit.platform` 1.14.4 to override the older version managed in `com.jcabi:parent` (without that override Jupiter 5.14 throws `NoSuchMethodError: EngineDiscoveryRequest.getOutputDirectoryCreator`)
- Add `jakarta.ws.rs:jakarta.ws.rs-api` 4.0.0 (now required by `jcabi-http` 2.x)
- Replace `com.sun.jersey:jersey-client` 1.19.4 with `org.glassfish.jersey.core:jersey-client` 3.1.10 (the jakarta-namespaced `RuntimeDelegate` provider that `jcabi-http` 2.x looks up at runtime), plus `jersey-hk2` for HK2 injection

## Source-code adjustments forced by these upgrades

- `TkAppAuth`: `PsByFlag.Pair` now takes a `Pattern` instead of a `String` — wrapped both flag names with `Pattern.compile(...)`.
- `TkAppFallback`: `RsVelocity` no longer accepts a `URL` — pass `URL.openStream()` instead.
- `TkRelay`: `TkProxy` constructor now takes a `URI` directly — dropped the redundant `.toString()`.
- `DyUsage`: replaced the deprecated `XML.node()` with `XML.deepCopy()` (jcabi-xml 0.35 turns the deprecation warning into a `-Werror` failure).

## CI / GitHub Actions

- `mvn.yml`: bumped Java matrix from `[11, 17]` to `[21]`. cactoos 0.61.0 is built for Java 17, so Java 11 jobs would no longer compile; aligning with the same matrix that jcabi-immutable, jcabi-velocity and other modern jcabi/yegor256 repos use.
- `actions/checkout` v4 → v6
- `actions/setup-java` v4 → v5
- `actions/setup-python` v5 → v6
- `actions/cache` v4 → v5
- `codecov/codecov-action` v5 → v6
- `fsfe/reuse-action` v5 → v6
- `crate-ci/typos` v1.32.0 → v1.46.0
- `yegor256/copyrights-action` 0.0.8 → 0.0.12
- `DavidAnson/markdownlint-cli2-action` v20.0.0 → v23

## Lint findings fixed (pre-existing on master)

Master was already red on `markdown-lint` and (via newer `crate-ci/typos`) on `typos`:

- `_typos.toml` (new): tell typos to ignore the Java parameter name `bse` (used to avoid shadowing the `base` field) and to skip `src/test/resources/io/jare/test`, which contains real CloudFront log lines that legitimately use the `TPE50` edge-location code.
- `README.md`: add a top-level H1, replace the inline `<img>` with the Markdown image syntax, and tag the shell code fence with `bash` so markdownlint-cli2 v23 stops complaining about MD040, MD033, MD041 and MD014.
- Added the SPDX header to `_typos.toml` so REUSE remains compliant.

## Out of scope

- `com.jcabi:jcabi-dynamo` was kept at `0.22.4` on purpose. The 1.x line is a hard cut-over from AWS SDK v1 (`com.amazonaws.*`) to AWS SDK v2 (`software.amazon.awssdk.*`), which would mean rewriting every `Dy*` class plus `Dynamo` itself (different `Region`, `Item`, `AttributeValue`, `Conditions`, `ScanValve`, `QueryValve`, etc.). That belongs in its own PR.

## Verification

`mvn --errors --batch-mode clean install -Pqulice` is green locally on JDK 21 (26 unit tests pass, qulice/checkstyle/PMD pass, integration tests run). I also ran the same set on a fork (https://github.com/bibonix/jare) and all CI workflows pass on Linux / Windows / macOS with Java 21:

- `mvn` ✅ (ubuntu-24.04, windows-2022, macos-15 all green)
- `actionlint`, `bashate`, `copyrights`, `markdown-lint`, `pdd`, `reuse`, `shellcheck`, `typos`, `xcop`, `yamllint` ✅
- `codecov` ❌ — pre-existing on `master` since it requires the `CODECOV_TOKEN` secret which forks cannot read; will pass on this PR once the upstream secret is wired in (master has been failing on this same step for several months).

Ready for merge.
